### PR TITLE
Potential fix for code scanning alert no. 103: Incomplete string escaping or encoding

### DIFF
--- a/src/selectors/CT/CurrentOnArt/currentOnArtVerifiedByAgeSex.js
+++ b/src/selectors/CT/CurrentOnArt/currentOnArtVerifiedByAgeSex.js
@@ -290,7 +290,7 @@ export const getCurrentOnArtByAgeSexLT15 = createSelector(
                             (obj) =>
                                 obj.ageGroup
                                     .replace('-', ' to ')
-                                    .replace('<', 'Under ') === ageGroup &&
+                                    .replace(/</g, 'Under ') === ageGroup &&
                                 (obj.Gender?.toLowerCase() ===
                                     'F'.toLowerCase() ||
                                     obj.Gender?.toLowerCase() ===
@@ -303,7 +303,7 @@ export const getCurrentOnArtByAgeSexLT15 = createSelector(
                           (obj) =>
                               obj.ageGroup
                                   .replace('-', ' to ')
-                                  .replace('<', 'Under ') === ageGroup &&
+                                  .replace(/</g, 'Under ') === ageGroup &&
                               (obj.Gender?.toLowerCase() === 'F'.toLowerCase() ||
                                   obj.Gender?.toLowerCase() ===
                                       'Female'.toLowerCase())


### PR DESCRIPTION
Potential fix for [https://github.com/palladiumkenya/dwh-portal/security/code-scanning/103](https://github.com/palladiumkenya/dwh-portal/security/code-scanning/103)

To fix the problem, we need to ensure that all occurrences of the character `<` in the `ageGroup` string are replaced. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that all instances of `<` are replaced with `Under `, providing complete and correct sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
