### PR TITLE
Potential fix for code scanning alert no. 71: Incomplete string escaping or encoding

### DIFF
--- a/src/selectors/CT/CurrentOnArt/currentOnArtVerifiedByAgeSex.js
+++ b/src/selectors/CT/CurrentOnArt/currentOnArtVerifiedByAgeSex.js
@@ -66,8 +66,8 @@ export const getCurrentOnArtByAgeSex = createSelector(
                         listAll.find(
                             (obj) =>
                                 obj.ageGroup
-                                    ?.replace('-', ' to ')
-                                    .replace('<', 'Under ') === ageGroup &&
+                                    ?.replace(/-/g, ' to ')
+                                    .replace(/</g, 'Under ') === ageGroup &&
                                 (obj.Gender?.toLowerCase() ===
                                     'M'.toLowerCase() ||
                                     obj.Gender?.toLowerCase() ===


### PR DESCRIPTION
Potential fix for [https://github.com/palladiumkenya/dwh-portal/security/code-scanning/71](https://github.com/palladiumkenya/dwh-portal/security/code-scanning/71)

To fix the problem, we need to ensure that all occurrences of the character `<` in the `ageGroup` string are replaced with the string `Under `. This can be achieved by using a regular expression with the global flag (`g`) in the `replace` method. This change will ensure that every occurrence of the character `<` is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
